### PR TITLE
Fix chat input textarea resize

### DIFF
--- a/components/ui/chat-input.tsx
+++ b/components/ui/chat-input.tsx
@@ -201,6 +201,14 @@ function ChatInputComponent({
     }
   }, [textareaRef]);
 
+  useEffect(() => {
+    if (input === "") {
+      adjustHeight(true);
+    } else {
+      adjustHeight();
+    }
+  }, [input, adjustHeight]);
+
   // Helper function to process files (either from input or paste) - use external if provided
   const processFilesForAttachment = useCallback(async (filesToProcess: File[]) => {
     if (externalProcessFilesForAttachment) {


### PR DESCRIPTION
## Summary
- update chat-input to reset height when input clears

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68528507c048832186c3e3f724a4f915