### PR TITLE
Add reasoning toggle to agent forms

### DIFF
--- a/app/agent/create/create-agent-form.tsx
+++ b/app/agent/create/create-agent-form.tsx
@@ -13,6 +13,8 @@ import { Loader2  } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { isReasoningModel } from "@/lib/models";
 import MultipleSelector, { Option } from "@/components/ui/multiselect";
 import {
   createAgent,
@@ -57,6 +59,7 @@ export function CreateAgentForm({ userId, models, allTags, allAvailableTools }: 
   const [isRemovingThumbnail, setIsRemovingThumbnail] = useState(false);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [isRemovingAvatar, setIsRemovingAvatar] = useState(false);
+  const [showReasoning, setShowReasoning] = useState(true);
   
   const [systemPrompt, setSystemPrompt] = useState<string>(""); // New state for system prompt
   const systemPromptRef = useRef<HTMLTextAreaElement>(null);
@@ -277,6 +280,7 @@ export function CreateAgentForm({ userId, models, allTags, allAvailableTools }: 
           systemPrompt: systemPrompt || null, // Use systemPrompt state
           thumbnailUrl: null,
           visibility: visibility,
+          showReasoning: showReasoning,
           primaryModelId: primaryModelId,
           creatorId: userId,
           welcomeMessage: null,
@@ -714,6 +718,21 @@ export function CreateAgentForm({ userId, models, allTags, allAvailableTools }: 
                 defaultValue={primaryModelId}
                 onValueChange={setPrimaryModelId}
               />
+              {(() => {
+                const selected = models.find(m => m.id === primaryModelId);
+                return selected && isReasoningModel(selected.model) ? (
+                  <div className="flex items-center gap-2 pt-2">
+                    <Switch
+                      id="showReasoning"
+                      checked={showReasoning}
+                      onCheckedChange={setShowReasoning}
+                    />
+                    <Label htmlFor="showReasoning" className="text-sm font-medium">
+                      Show reasoning in chat
+                    </Label>
+                  </div>
+                ) : null;
+              })()}
               <p className="text-xs text-muted-foreground">
                 {`Choose the model that best fits your agent's purpose. Different models have different capabilities.`}
               </p>

--- a/components/agents/settings/agent-info-form.tsx
+++ b/components/agents/settings/agent-info-form.tsx
@@ -18,6 +18,7 @@ import { Loader2 } from 'lucide-react';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { VisibilitySelector } from '@/components/visibility-selector';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
 import { updateAgentAction, uploadAgentImageAction, removeAgentImageAction } from '@/db/actions/agent.actions';
 
 interface AgentInfoFormProps {
@@ -34,6 +35,7 @@ const AgentInfoForm = ({ agent }: AgentInfoFormProps) => {
   const [visibility, setVisibility] = useState<"public" | "private" | "link">(
     agent.visibility as "public" | "private" | "link"
   );
+  const [showReasoning, setShowReasoning] = useState<boolean>(agent.showReasoning);
   
   // Image upload states
   const [isUploadingThumbnail, setIsUploadingThumbnail] = useState(false);
@@ -59,6 +61,7 @@ const AgentInfoForm = ({ agent }: AgentInfoFormProps) => {
           thumbnailUrl,
           avatarUrl,
           visibility,
+          showReasoning,
         };
 
         // Execute update
@@ -379,10 +382,21 @@ const AgentInfoForm = ({ agent }: AgentInfoFormProps) => {
             </div>
 
             <VisibilitySelector
-              value={visibility} 
+              value={visibility}
               onValueChange={setVisibility}
             />
-            
+
+            <div className="flex items-center gap-2">
+              <Switch
+                id="showReasoning"
+                checked={showReasoning}
+                onCheckedChange={setShowReasoning}
+              />
+              <Label htmlFor="showReasoning" className="text-sm font-medium">
+                Show reasoning in chat
+              </Label>
+            </div>
+
             {/* Save Button */}
             <div className="flex justify-end">
               <Button 


### PR DESCRIPTION
## Summary
- toggle reasoning visibility when creating agents
- add reasoning switch on agent info settings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c2635a7d88321a10f6cdebd334db7