### PR TITLE
Implement reasoning placeholder

### DIFF
--- a/components/chat-mobile.tsx
+++ b/components/chat-mobile.tsx
@@ -12,6 +12,7 @@ import { useChatManager, type AgentSpecificModel } from '@/hooks/use-chat-manage
 import { useAttachmentManager } from '@/hooks/use-attachment-manager';
 import type { ChatRequestOptions } from '@ai-sdk/ui-utils';
 import { CreditErrorDialog } from './credit-error-dialog'
+import { isReasoningModel } from '@/lib/models';
 
 interface ChatMobileProps {
   chatId: string;
@@ -97,6 +98,9 @@ export default function ChatMobile({
   // @ts-expect-error There's a version mismatch between UIMessage types
   const messagesProp: UIMessage[] = messages;
 
+  const selected = agentModels.find(m => m.modelId === selectedModelId);
+  const hideReasoning = !agent.showReasoning && selected && isReasoningModel(selected.model);
+
   return (
     <div className="flex flex-col h-full px-2">
       <MobileAgentHeader
@@ -121,6 +125,7 @@ export default function ChatMobile({
             reload={reload}
             isReadonly={false}
             isArtifactVisible={false}
+            hideReasoning={hideReasoning}
             externalScrollContainerRef={mobileScrollContainerRef}
           />
         ) : (

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -13,6 +13,7 @@ import { useAttachmentManager } from '@/hooks/use-attachment-manager';
 import { useDragDrop } from '@/hooks/use-drag-drop';
 import type { ChatRequestOptions } from '@ai-sdk/ui-utils';
 import { CreditErrorDialog } from './credit-error-dialog';
+import { isReasoningModel } from '@/lib/models';
 
 interface ChatProps {
   chatId: string;
@@ -75,6 +76,9 @@ export default function Chat({
     onFilesDropped: attachmentManager.processFilesForAttachment
   });
 
+  const selected = agentModels.find(m => m.modelId === selectedModelId);
+  const hideReasoning = !agent.showReasoning && selected && isReasoningModel(selected.model);
+
   // Enhanced submit handler that includes attachment data
   const handleEnhancedSubmit = React.useCallback((
     event?: { preventDefault?: (() => void) | undefined; } | undefined, 
@@ -125,6 +129,7 @@ export default function Chat({
               reload={reload}
               isReadonly={false}
               isArtifactVisible={false}
+              hideReasoning={hideReasoning}
             />
             <ChatInput
               userId={agent.creatorId}

--- a/components/chat/message-reasoning.tsx
+++ b/components/chat/message-reasoning.tsx
@@ -9,11 +9,13 @@ import { Markdown } from '@/components/chat/markdown';
 interface MessageReasoningProps {
   isLoading: boolean;
   reasoning: string;
+  hideReasoning?: boolean;
 }
 
 export function MessageReasoning({
   isLoading,
   reasoning,
+  hideReasoning = false,
 }: MessageReasoningProps) {
   // Ensure reasoning is always a string
   const reasoningText = typeof reasoning === 'string' ? reasoning : JSON.stringify(reasoning);
@@ -106,7 +108,7 @@ export function MessageReasoning({
       )}
 
       <AnimatePresence initial={false}>
-        {isExpanded && (
+        {isExpanded && !hideReasoning && (
           <motion.div
             key="content"
             initial="collapsed"

--- a/components/chat/messages.tsx
+++ b/components/chat/messages.tsx
@@ -20,6 +20,7 @@ interface MessagesProps {
   reload: UseChatHelpers['reload'];
   isReadonly: boolean;
   isArtifactVisible: boolean;
+  hideReasoning?: boolean;
   // Allow null for the external ref prop type
   externalScrollContainerRef?: React.RefObject<HTMLDivElement | null>;
 }
@@ -32,6 +33,7 @@ function PureMessages({
   reload,
   isReadonly,
   // Destructure the new prop
+  hideReasoning,
   externalScrollContainerRef,
 }: MessagesProps) {
 
@@ -92,6 +94,7 @@ function PureMessages({
             setMessages={setMessages}
             reload={reload}
             isReadonly={isReadonly}
+            hideReasoning={hideReasoning}
           />
         </div>
       ))}
@@ -137,6 +140,7 @@ export const Messages = memo(PureMessages, (prevProps, nextProps) => {
   if (!equal(prevProps.messages, nextProps.messages)) return false;
   // Add comparison for the new prop
   if (prevProps.externalScrollContainerRef !== nextProps.externalScrollContainerRef) return false;
+  if (prevProps.hideReasoning !== nextProps.hideReasoning) return false;
 
   return true;
 });


### PR DESCRIPTION
## Summary
- allow message reasoning component to hide actual reasoning text
- propagate `hideReasoning` through chat components and compute based on agent setting and model type

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687c20ba0404832199c5f815430c0f0c