### PR TITLE
Add Daily Active Users chart

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'; // Import Tabs components
 import { toolRegistry } from '@/tools/registry'; // Import the tool registry
+import DailyActiveUsersChart from '@/components/admin/daily-active-users-chart';
 
 // Define a simple component for unauthorized access
 function UnauthorizedAccess() { // This component might not be reached if auth check is only in action
@@ -161,6 +162,7 @@ export default async function AdminPage() {
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8 space-y-6">
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+      <DailyActiveUsersChart />
 
       <Tabs defaultValue="users" className="w-full">
         <TabsList className="grid w-full grid-cols-5">

--- a/components/admin/daily-active-users-chart.tsx
+++ b/components/admin/daily-active-users-chart.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDailyActiveUsersAction } from '@/db/actions/analytics.actions';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+
+interface ChartPoint {
+  day: string;
+  activeUsers: number;
+}
+
+export default function DailyActiveUsersChart() {
+  const [range, setRange] = useState<7 | 30 | 90>(7);
+  const [data, setData] = useState<ChartPoint[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const result = await getDailyActiveUsersAction(range);
+      if (result.success) {
+        setData(
+          result.data.map((d) => ({
+            day: new Date(d.day).toLocaleDateString(),
+            activeUsers: d.activeUsers,
+          }))
+        );
+      }
+    };
+    load();
+  }, [range]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Daily Active Users</CardTitle>
+          <Select value={String(range)} onValueChange={(val) => setRange(Number(val) as 7 | 30 | 90)}>
+            <SelectTrigger className="w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">7 days</SelectItem>
+              <SelectItem value="30">30 days</SelectItem>
+              <SelectItem value="90">90 days</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={{ activeUsers: { label: 'Users' } }} className="min-h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="day" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} />
+              <Tooltip content={<ChartTooltipContent indicator="line" />} />
+              <Line type="monotone" dataKey="activeUsers" stroke="var(--chart-1)" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/db/actions/analytics.actions.ts
+++ b/db/actions/analytics.actions.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { selectDailyActiveUsers } from '@/db/repository/analytics.repository';
+import { requireAdmin } from '@/lib/auth-utils';
+import type { ActionResult } from './types';
+
+export async function getDailyActiveUsersAction(days: number): Promise<ActionResult<ReturnType<typeof selectDailyActiveUsers>>> {
+  if (!days || days <= 0) {
+    return { success: false, error: 'Invalid number of days.' };
+  }
+
+  const auth = await requireAdmin();
+  if (!auth.success) {
+    return { success: false, error: auth.error ?? 'Admin access required' };
+  }
+
+  try {
+    const data = await selectDailyActiveUsers(days);
+    return { success: true, data };
+  } catch (error) {
+    console.error('Failed to fetch daily active users:', error);
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/db/repository/analytics.repository.ts
+++ b/db/repository/analytics.repository.ts
@@ -1,0 +1,36 @@
+import { db } from '..';
+import { chat, message } from '../schema/chat';
+import { sql, eq, gte } from 'drizzle-orm';
+
+export type DailyActiveUsersRow = {
+  day: Date;
+  activeUsers: number;
+};
+
+/**
+ * Returns the number of unique users that sent a message on each day
+ * within the given time range.
+ */
+export async function selectDailyActiveUsers(days: number): Promise<DailyActiveUsersRow[]> {
+  const from = new Date();
+  from.setUTCHours(0, 0, 0, 0);
+  from.setDate(from.getDate() - (days - 1));
+
+  const dayColumn = sql`date_trunc('day', ${message.createdAt})`;
+
+  const results = await db
+    .select({
+      day: dayColumn,
+      activeUsers: sql<number>`count(distinct ${chat.userId})`,
+    })
+    .from(message)
+    .innerJoin(chat, eq(message.chatId, chat.id))
+    .where(gte(message.createdAt, from))
+    .groupBy(dayColumn)
+    .orderBy(dayColumn);
+
+  return results.map((row) => ({
+    day: row.day as unknown as Date,
+    activeUsers: Number(row.activeUsers),
+  }));
+}


### PR DESCRIPTION
## Summary
- add DB query for daily active users
- add server action guarded by admin check
- add chart component in admin dashboard
- display daily active users chart in admin page

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687c3510719c8321a2cebff3203ae736