### PR TITLE
Add model list comparison utilities

### DIFF
--- a/components/admin/model-management.tsx
+++ b/components/admin/model-management.tsx
@@ -43,12 +43,15 @@ import { toast } from 'sonner';
 // Removed SearchIcon import
 import { LoaderIcon, PlusIcon, PencilEditIcon, TrashIcon } from '@/components/utils/icons';
 import { ActionResult } from '@/db/actions/types';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 interface ModelManagementProps {
   initialModels: Model[];
+  missingInDb?: string[];
+  missingLocally?: string[];
 }
 
-export default function ModelManagement({ initialModels }: ModelManagementProps) {
+export default function ModelManagement({ initialModels, missingInDb = [], missingLocally = [] }: ModelManagementProps) {
   const [models, setModels] = useState<Model[]>(initialModels);
   const [isPending, startTransition] = useTransition();
   const [searchTerm, setSearchTerm] = useState(''); // State for search term
@@ -187,9 +190,41 @@ export default function ModelManagement({ initialModels }: ModelManagementProps)
          <Button onClick={() => openDialog(null)} disabled={isPending}>
            <PlusIcon size={16} className="mr-2 h-4 w-4" />
            Create Model
-         </Button>
+        </Button>
       </div>
 
+      {(missingInDb.length > 0 || missingLocally.length > 0) && (
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Model List Mismatch</CardTitle>
+            <CardDescription>
+              Discrepancies detected between local model definitions and the database.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-destructive">
+            {missingInDb.length > 0 && (
+              <div>
+                <p className="font-medium text-sm">Missing in Database:</p>
+                <ul className="list-disc list-inside text-sm">
+                  {missingInDb.map((name) => (
+                    <li key={name}>{name}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {missingLocally.length > 0 && (
+              <div>
+                <p className="font-medium text-sm">Missing Locally:</p>
+                <ul className="list-disc list-inside text-sm">
+                  {missingLocally.map((name) => (
+                    <li key={name}>{name}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Models Table */}
       <div className="rounded-md border">

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1369,3 +1369,6 @@ export function getModelPricing(modelId: string): ModelDetails {
 export function isReasoningModel(modelId: string): boolean {
   return modelDetails[modelId]?.isReasoningModel === true;
 }
+
+// Helper array of all model IDs defined locally
+export const localModelIds = Object.keys(modelDetails);


### PR DESCRIPTION
## Summary
- export `localModelIds` helper from models
- add `compareModelListsAction` to detect mismatched model IDs
- surface mismatch info on admin dashboard
- display mismatched model names in model management UI

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_687e7574f6908321ae313eb175f10acf