### PR TITLE
Add daily signups chart

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'; // Import Tabs components
 import { toolRegistry } from '@/tools/registry'; // Import the tool registry
 import DailyActiveUsersChart from '@/components/admin/daily-active-users-chart';
+import DailySignupsChart from '@/components/admin/daily-signups-chart';
 
 // Define a simple component for unauthorized access
 function UnauthorizedAccess() { // This component might not be reached if auth check is only in action
@@ -180,7 +181,18 @@ export default async function AdminPage() {
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8 space-y-6">
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
-      <DailyActiveUsersChart />
+      <Tabs defaultValue="active" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-4">
+          <TabsTrigger value="active">Active Users</TabsTrigger>
+          <TabsTrigger value="signups">Sign Ups</TabsTrigger>
+        </TabsList>
+        <TabsContent value="active">
+          <DailyActiveUsersChart />
+        </TabsContent>
+        <TabsContent value="signups">
+          <DailySignupsChart />
+        </TabsContent>
+      </Tabs>
 
       <Tabs defaultValue="users" className="w-full">
         <TabsList className="grid w-full grid-cols-5">

--- a/components/admin/daily-signups-chart.tsx
+++ b/components/admin/daily-signups-chart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDailySignupsAction } from '@/db/actions/analytics.actions';
+import type { DailySignupsRow } from '@/db/repository/analytics.repository';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+
+interface ChartPoint {
+  day: string;
+  signups: number;
+}
+
+export default function DailySignupsChart() {
+  const [range, setRange] = useState<7 | 30 | 90>(7);
+  const [data, setData] = useState<ChartPoint[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const result = await getDailySignupsAction(range);
+      if (result.success) {
+        setData(
+          result.data.map((d: DailySignupsRow) => ({
+            day: new Date(d.day).toLocaleDateString(),
+            signups: d.signups,
+          }))
+        );
+      }
+    };
+    load();
+  }, [range]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Daily Sign Ups</CardTitle>
+          <Select value={String(range)} onValueChange={(val) => setRange(Number(val) as 7 | 30 | 90)}>
+            <SelectTrigger className="w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">7 days</SelectItem>
+              <SelectItem value="30">30 days</SelectItem>
+              <SelectItem value="90">90 days</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={{ signups: { label: 'Signups' } }} className="min-h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="day" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} />
+              <Tooltip content={<ChartTooltipContent indicator="line" />} />
+              <Line type="monotone" dataKey="signups" stroke="var(--chart-1)" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/db/actions/analytics.actions.ts
+++ b/db/actions/analytics.actions.ts
@@ -1,6 +1,9 @@
 'use server';
 
-import { selectDailyActiveUsers } from '@/db/repository/analytics.repository';
+import {
+  selectDailyActiveUsers,
+  selectDailySignups,
+} from '@/db/repository/analytics.repository';
 import { requireAdmin } from '@/lib/auth-utils';
 import type { ActionResult } from './types';
 
@@ -19,6 +22,25 @@ export async function getDailyActiveUsersAction(days: number): Promise<ActionRes
     return { success: true, data };
   } catch (error) {
     console.error('Failed to fetch daily active users:', error);
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function getDailySignupsAction(days: number): Promise<ActionResult<Awaited<ReturnType<typeof selectDailySignups>>>> {
+  if (!days || days <= 0) {
+    return { success: false, error: 'Invalid number of days.' };
+  }
+
+  const auth = await requireAdmin();
+  if (!auth.success) {
+    return { success: false, error: auth.error ?? 'Admin access required' };
+  }
+
+  try {
+    const data = await selectDailySignups(days);
+    return { success: true, data };
+  } catch (error) {
+    console.error('Failed to fetch daily signups:', error);
     return { success: false, error: (error as Error).message };
   }
 }


### PR DESCRIPTION
## Summary
- query daily sign-ups data in the analytics repository
- expose a `getDailySignupsAction` server action
- create `DailySignupsChart` component
- allow switching between active users and sign-up charts in admin dashboard

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687e898e0370832181a7bcd7ccb57389