### PR TITLE
feat: add GPT-5 model family

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -202,7 +202,7 @@ export async function POST(req: Request) {
 
     // Prepare final settings, potentially renaming maxTokens
     const finalSettings: Record<string, number | undefined> = { ...receivedSettings };
-    const modelsRequiringMaxCompletionTokens = ['gpt-4o-mini', 'o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini']; // Add other relevant models as needed
+    const modelsRequiringMaxCompletionTokens = ['gpt-4o-mini', 'o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini', 'gpt-5-mini', 'gpt-5-nano']; // Add other relevant models as needed
 
     if (modelsRequiringMaxCompletionTokens.includes(modelId) && finalSettings.maxTokens !== undefined) {
       finalSettings.maxCompletionTokens = finalSettings.maxTokens;

--- a/components/ui/filters.tsx
+++ b/components/ui/filters.tsx
@@ -132,6 +132,9 @@ export enum Agent {
 export const Model = {
   GPT_4O: "gpt-4o",
   GPT_4O_MINI: "gpt-4o-mini",
+  GPT_5: "gpt-5",
+  GPT_5_MINI: "gpt-5-mini",
+  GPT_5_NANO: "gpt-5-nano",
   O1: "o1",
   O3_MINI: "o3-mini",
   CLAUDE_3_7_SONNET: "claude-3-7-sonnet-20250219",

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -29,6 +29,9 @@ export const myProvider = customProvider({
     'o3-mini': openai('o3-mini'),
     'o3': openai('o3'),
     'o4-mini': openai('o4-mini'),
+    'gpt-5': openai('gpt-5'),
+    'gpt-5-mini': openai('gpt-5-mini'),
+    'gpt-5-nano': openai('gpt-5-nano'),
 
     // Perplexity Models
     'sonar-pro': perplexity('sonar-pro'),
@@ -363,6 +366,109 @@ export const modelDetails: Record<string, ModelDetails> = {
     defaultSettings: {
       maxOutputTokens: {
         default: 2048,
+        min: 50,
+        max: 2048
+      },
+      temperature: {
+        default: 0.7,
+        min: 0,
+        max: 2
+      },
+      topP: {
+        default: 1,
+        min: 0,
+        max: 1
+      },
+      frequencyPenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      },
+      presencePenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      }
+    }
+  },
+
+  'gpt-5': {
+    displayName: "GPT-5",
+    description: "OpenAI's next-generation flagship model for advanced multimodal tasks.",
+    inputCostPerMillion: 1.25,
+    outputCostPerMillion: 10.00,
+    contextWindow: 1_000_000,
+    defaultSettings: {
+      maxOutputTokens: {
+        default: 1024,
+        min: 50,
+        max: 2048
+      },
+      temperature: {
+        default: 0.7,
+        min: 0,
+        max: 2
+      },
+      topP: {
+        default: 1,
+        min: 0,
+        max: 1
+      },
+      frequencyPenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      },
+      presencePenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      }
+    }
+  },
+  'gpt-5-mini': {
+    displayName: "GPT-5 Mini",
+    description: "Smaller, cost-effective GPT-5 model for general use.",
+    inputCostPerMillion: 0.25,
+    outputCostPerMillion: 2.00,
+    contextWindow: 1_000_000,
+    defaultSettings: {
+      maxOutputTokens: {
+        default: 1024,
+        min: 50,
+        max: 2048
+      },
+      temperature: {
+        default: 0.7,
+        min: 0,
+        max: 2
+      },
+      topP: {
+        default: 1,
+        min: 0,
+        max: 1
+      },
+      frequencyPenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      },
+      presencePenalty: {
+        default: 0,
+        min: 0,
+        max: 2
+      }
+    }
+  },
+  'gpt-5-nano': {
+    displayName: "GPT-5 Nano",
+    description: "Fastest, most efficient GPT-5 variant.",
+    inputCostPerMillion: 0.05,
+    outputCostPerMillion: 0.40,
+    contextWindow: 1_000_000,
+    defaultSettings: {
+      maxOutputTokens: {
+        default: 1024,
         min: 50,
         max: 2048
       },
@@ -1357,6 +1463,9 @@ export function getModelInstanceById(modelId: string): LanguageModel {
     'o3-mini': openai('o3-mini'),
     'o3': openai('o3'),
     'o4-mini': openai('o4-mini'),
+    'gpt-5': openai('gpt-5'),
+    'gpt-5-mini': openai('gpt-5-mini'),
+    'gpt-5-nano': openai('gpt-5-nano'),
     // Perplexity
     'sonar-pro': perplexity('sonar-pro'),
     'sonar': perplexity('sonar'),


### PR DESCRIPTION
## Summary
- register GPT-5, GPT-5-mini and GPT-5-nano with OpenAI provider and model map
- define pricing, context window and defaults for GPT-5 models
- surface GPT-5 models in UI filters and adjust maxCompletionTokens handling

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Failed to fetch font `Geist`)*
- `npx tsx -e "import('./db/actions/model.actions.ts').then(async m => { const res = await m.compareModelListsAction(); console.log(JSON.stringify(res, null, 2)); })"` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6894e49d48188321ab28734b4c247b39